### PR TITLE
Allow trailing whitespace after AutoDoc-style comments

### DIFF
--- a/gaplint.py
+++ b/gaplint.py
@@ -1264,7 +1264,7 @@ def __init_rules(args):
         WarnRegexLine(
             "trailing-whitespace",
             "W007",
-            r"\s+$",
+            r"^(?!#\!).*\s+$",
             "Trailing whitespace",
             [],
             _is_tst_or_xml_file,

--- a/tests/test5.g
+++ b/tests/test5.g
@@ -1,0 +1,43 @@
+#! @BeginGroup XTranslation
+#! @GroupTitle XTranslation
+#! @Returns a left or right translation
+#! @Arguments T, x[, y]
+#! @Description
+#! For the semigroup <A>T</A> of left or right translations of a semigroup <M>
+#! S</M> and <A>x</A> one of:
+#! * a mapping on the underlying semigroup; note that in this case only the
+#!   values of the mapping on the <Ref Attr="UnderlyingRepresentatives"/> of
+#!   <A>T</A> are checked and used, so mappings which do not define translations
+#!   can be used to create translations if they are valid on that subset of S;
+#! * a list of indices representing the images of the
+#!   <Ref Attr="UnderlyingRepresentatives"/> of <A>T</A>, where the ordering
+#!   is that of <Ref Oper="PositionCanonical"/> on <A>S</A>;
+#! * (for `LeftTranslation`) a list of length `Length(Rows(S))`
+#!   containing elements of `UnderlyingSemigroup(S)`; in this case
+#!   <A>S</A> must be a normalised Rees matrix semigroup and `y` must be
+#!   a Transformation of `Rows(S)`;
+#! * (for `RightTranslation`) a list of length `Length(Columns(S))`
+#!   containing elements of `UnderlyingSemigroup(S)`; in this case
+#!   <A>S</A> must be a normalised Rees matrix semigroup and `y` must be
+#!   a Transformation of `Columns(S)`;
+#! `LeftTranslation` and `RightTranslation` return the corresponding
+#! translations.
+#! @BeginExampleSession
+#! gap> S := RectangularBand(3, 4);;
+#! gap> L := LeftTranslations(S);;
+#! gap> s := AsList(S)[1];;
+#! gap> f := function(x)
+#! > return s * x;
+#! > end;;
+#! gap> map := MappingByFunction(S, S, f);;
+#! gap> l := LeftTranslation(L, map);
+#! <left translation on <regular transformation semigroup of size 12, 
+#!  degree 8 with 4 generators>>
+#! gap> s ^ l;
+#! Transformation( [ 1, 2, 1, 1, 5, 5, 5, 5 ] )
+#! @EndExampleSession
+DeclareOperation("LeftTranslation",
+                 [IsLeftTranslationsSemigroup, IsGeneralMapping]);
+DeclareOperation("RightTranslation",
+                 [IsRightTranslationsSemigroup, IsGeneralMapping]);
+#! @EndGroup

--- a/tests/test_gaplint.py
+++ b/tests/test_gaplint.py
@@ -59,6 +59,10 @@ class TestScript(unittest.TestCase):
             gaplint._info_verbose("test/tests.g", 0, "msg")
         gaplint._info_verbose("message")
 
+    def test_autodoc_whitespace(self):
+        with self.assertRaises(SystemExit):
+            run_gaplint(files=["tests/test5.g"])
+
 
 class TestRules(unittest.TestCase):
     # def test_ReplaceMultilineStrings(self):


### PR DESCRIPTION
I'm not really sure if this is the right remedy, but if tests are included in AutoDoc documentation in .gd files then trailing whitespace might be required.
