### PR TITLE
Fix config file detection

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/gaplint.py
+++ b/gaplint.py
@@ -1116,23 +1116,18 @@ def __config_yml_path(dir_path):
     cases A, B, C.
     """
     assert os.path.isdir(dir_path)
-    entries = os.listdir(dir_path)  # initialise list of entries in the...
-    # ...directory we are currently searching
-    for entry in entries:
-        # if entry a directory, True, else False
-        entry_isdir = os.path.isdir(
-            os.path.abspath(os.path.join(dir_path, entry))
-        )
-        if entry_isdir and entry == ".git":  # base case A
-            return None
-        if not entry_isdir and entry == ".gaplint.yml":  # base case B
-            yml_path = os.path.abspath(os.path.join(dir_path, ".gaplint.yml"))
-            return yml_path
-    # if A and B not satisfied, recursive call made on parent directory
+    entries = os.listdir(dir_path)
+
+    if ".gaplint.yml" in entries:
+        yml_path = os.path.abspath(os.path.join(dir_path, ".gaplint.yml"))
+        return yml_path
+    if ".git" in entries and os.path.isdir(
+        os.path.abspath(os.path.join(dir_path, ".git"))
+    ):
+        return None
+
     pardir_path = os.path.abspath(os.path.join(dir_path, os.pardir))
-    # when os.pardir is called on the root directory path, it just returns the
-    # path to the root directory again, hence
-    if pardir_path == dir_path:  # base case C
+    if pardir_path == dir_path:
         return None
     return __config_yml_path(pardir_path)  # recursive call
 

--- a/gaplint.py
+++ b/gaplint.py
@@ -11,6 +11,9 @@ import os
 import re
 import sys
 
+from os import listdir
+from os.path import isdir, exists, isfile, abspath, join
+
 import pkg_resources
 import yaml
 
@@ -1071,7 +1074,7 @@ def _parse_args(kwargs):
 
     files = []
     for fname in args.files:
-        if not (os.path.exists(fname) and os.path.isfile(fname)):
+        if not (exists(fname) and isfile(fname)):
             _info_action("SKIPPING " + fname + ": cannot open for reading")
         elif (
             not fname.split(".")[-1] in _VALID_EXTENSIONS
@@ -1115,18 +1118,16 @@ def __config_yml_path(dir_path):
     root directory has been searched (script not found, returns None) - base
     cases A, B, C.
     """
-    assert os.path.isdir(dir_path)
-    entries = os.listdir(dir_path)
+    assert isdir(dir_path)
+    entries = listdir(dir_path)
 
     if ".gaplint.yml" in entries:
-        yml_path = os.path.abspath(os.path.join(dir_path, ".gaplint.yml"))
+        yml_path = abspath(join(dir_path, ".gaplint.yml"))
         return yml_path
-    if ".git" in entries and os.path.isdir(
-        os.path.abspath(os.path.join(dir_path, ".git"))
-    ):
+    if ".git" in entries and isdir(abspath(join(dir_path, ".git"))):
         return None
 
-    pardir_path = os.path.abspath(os.path.join(dir_path, os.pardir))
+    pardir_path = abspath(join(dir_path, os.pardir))
     if pardir_path == dir_path:
         return None
     return __config_yml_path(pardir_path)  # recursive call


### PR DESCRIPTION
This hopefully resolves https://github.com/gap-system/gap/issues/5316.

Previously the order that files were listed in a directory determined whether or not the config file was detected. Clearly this is nonsense. I think we never detected this before because in Digraphs and Semigroups we are not disable many rules, and so whether the config file was detected or not was not very important. 