### PR TITLE
Update setup.cfg to use _ and not -

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [wheel]
 universal = 1
 [metadata]
-description-file = README.rst
+description_file = README.rst


### PR DESCRIPTION
This should resolve issue #29, from the issue the following warning is issued by:

/usr/lib/python3.11/site-packages/setuptools/dist.py:476: SetuptoolsDeprecationWarning: Invalid dash-separated options !!

Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead.

By 2024-Sep-26, you need to update your project and remove deprecated calls or your builds will no longer be supported.

See
https://setuptools.pypa.io/en/latest/userguide/declarative_config.html