### PR TITLE
Don't add command line args if running in pytest

### DIFF
--- a/gaplint.py
+++ b/gaplint.py
@@ -1693,8 +1693,7 @@ def main(**kwargs) -> None:
         silent (bool):        no output but all rules run
         verbose (bool):       so much output you will not know what to do
     """
-
-    if __name__ != "__main__":
+    if "PYTEST_CURRENT_TEST" in os.environ:
         sys.argv = []
     args = _parse_args(kwargs)
 


### PR DESCRIPTION
Hopefully this properly resolves issue #31, unlike the previous attempt that did resolve the issue but rendered gaplint completely useless.