### PR TITLE
Fix incorrect state reset bug in `W047`, improve reset in other rules

### DIFF
--- a/gaplint.py
+++ b/gaplint.py
@@ -1027,7 +1027,7 @@ class UnalignedPatterns(Rule):
         assert isinstance(pattern, str)
         assert isinstance(group, int)
         assert isinstance(msg, str)
-        self.reset()
+        self._last_line_col = None
         self._pattern = re.compile(pattern)
         self._group = group
         self._msg = msg

--- a/gaplint.py
+++ b/gaplint.py
@@ -577,8 +577,6 @@ class AnalyseLVars(Rule):  # pylint: disable=too-many-instance-attributes
         self._ws2_p = re.compile(r"\n[ \t\r\f\v]+")
         self._rec_p = re.compile(r"\brec\(")
         self._comment_p = re.compile(r" *#.*?\n")
-        self._func_bodies = []
-        self._func_position = []
 
     def reset(self) -> None:
         self._depth = -1
@@ -587,6 +585,8 @@ class AnalyseLVars(Rule):  # pylint: disable=too-many-instance-attributes
         self._assigned_lvars = []
         self._used_lvars = []
         self._func_start_pos = []
+        self._func_bodies = []
+        self._func_position = []
 
     def _remove_recs_and_whitespace(self, lines: str) -> str:
         # Remove almost all whitespace
@@ -1027,7 +1027,7 @@ class UnalignedPatterns(Rule):
         assert isinstance(pattern, str)
         assert isinstance(group, int)
         assert isinstance(msg, str)
-        self._last_line_col = None
+        self.reset()
         self._pattern = re.compile(pattern)
         self._group = group
         self._msg = msg
@@ -1053,6 +1053,9 @@ class UnalignedPatterns(Rule):
                 return nr_warnings + 1, lines
         self._last_line_col = col
         return nr_warnings, lines
+
+    def reset(self) -> None:
+        self._last_line_col = None
 
 
 class Indentation(Rule):
@@ -2255,6 +2258,8 @@ def main(  # pylint: disable=too-many-locals, too-many-statements, too-many-bran
                     )
         too_many_warnings(nr_warnings + total_num_warnings)
         for rule in _LINE_RULES:
+            rule.reset()
+        for rule in _FILE_RULES:
             rule.reset()
         total_num_warnings += nr_warnings
 

--- a/tests/test_gaplint.py
+++ b/tests/test_gaplint.py
@@ -59,7 +59,7 @@ def test_dot_g_file1():
         "W044": 0,
         "W045": 0,
         "W046": 6,
-        "W047": 4,
+        "W047": 3,
         "W048": 0,
     }
 
@@ -410,13 +410,6 @@ def test_enable_and_disable():
                     name="analyse-lvars",
                     line=63,
                     message="Variables assigned but never used: test",
-                    filename="tests/test1.g",
-                ),
-                Diagnostic(
-                    code="W047",
-                    name="duplicate-function",
-                    line=63,
-                    message='Duplicate function with 5 > 4 lines (from "function" to "end" inclusive), previously defined at tests/test1.g:63!',
                     filename="tests/test1.g",
                 ),
                 Diagnostic(
@@ -3645,13 +3638,6 @@ def test_enable_and_disable():
                     filename="tests/filter.gi",
                 ),
                 Diagnostic(
-                    code="W047",
-                    name="duplicate-function",
-                    line=56,
-                    message='Duplicate function with 5 > 4 lines (from "function" to "end" inclusive), previously defined at tests/filter.gi:56!',
-                    filename="tests/filter.gi",
-                ),
-                Diagnostic(
                     code="W046",
                     name="unused-func-args",
                     line=63,
@@ -3670,13 +3656,6 @@ def test_enable_and_disable():
                     name="use-return-false",
                     line=78,
                     message="Replace one line function by ReturnFalse",
-                    filename="tests/filter.gi",
-                ),
-                Diagnostic(
-                    code="W047",
-                    name="duplicate-function",
-                    line=40,
-                    message='Duplicate function with 14 > 4 lines (from "function" to "end" inclusive), previously defined at tests/filter.gi:40!',
                     filename="tests/filter.gi",
                 ),
                 Diagnostic(


### PR DESCRIPTION
This PR fixes some bugs relating to rule states persisting between repeated runs on gaplint. In particular `W047` would incorrectly report duplicate definitions when run on the same file twice. The bug could also be triggered if a function is defined twice in two different files. 

Similarly, the state of `UnalignedPatterns` rules is now reset. This could cause very rare bugs if two consecutive files being parsed by gaplint in a single run both contained an assignment immediately one after the other.

File rules are now reset in addition to line rules inbetween file runs.