### PR TITLE
Separate cmd line args parsing

### DIFF
--- a/gaplint.py
+++ b/gaplint.py
@@ -1320,21 +1320,16 @@ def __explain(args: Dict[str, Any]) -> None:
     sys.exit(0)
 
 
-def _parse_cmd_line_args(kwargs) -> Dict[str, Any]:
+def _parse_cmd_line_args() -> Dict[str, Any]:
     """
-    Pass kwargs as an argument for the check for \"files\" o/w not needed.
     Note that the default value for each argument is set to None here, so that
     we can detect where a parameter was actually set in __merge_args. The
     actual default value is installed in __merge_args.
     """
-    script_name = os.path.basename(sys.argv[0])
-    if script_name in ["pytest", "py.test"]:
-        return {}
     parser = argparse.ArgumentParser(
         prog="gaplint", usage="%(prog)s [options] files"
     )
-    if "files" not in kwargs:
-        parser.add_argument("files", nargs="*", help="the files to lint")
+    parser.add_argument("files", nargs="*", help="the files to lint")
 
     default = _DEFAULT_CONFIG["max-warnings"]
     parser.add_argument(
@@ -2339,6 +2334,7 @@ def __at_exit(
 
 # TODO fix linting errors here
 def main(  # pylint: disable=too-many-locals, too-many-statements, too-many-branches
+    _cmd_line_args = None,
     **kwargs,
 ) -> None:
     """
@@ -2374,7 +2370,10 @@ def main(  # pylint: disable=too-many-locals, too-many-statements, too-many-bran
         _info_verbose("Debug off . . .")
 
     # gather args from different places
-    cmd_line_args = _parse_cmd_line_args(kwargs)
+    if _cmd_line_args is None:
+        cmd_line_args = {}
+    else:
+        cmd_line_args = _cmd_line_args
     kwargs = _parse_kwargs(kwargs)
     config_yml_fname, yml_dic = _parse_yml_config()
 
@@ -2457,4 +2456,5 @@ def main(  # pylint: disable=too-many-locals, too-many-statements, too-many-bran
 
 
 if __name__ == "__main__":
-    main()
+    _cmd_line_args = _parse_cmd_line_args()
+    main(_cmd_line_args)

--- a/gaplint.py
+++ b/gaplint.py
@@ -1327,9 +1327,8 @@ def _parse_cmd_line_args() -> Dict[str, Any]:
     actual default value is installed in __merge_args.
     """
     parser = argparse.ArgumentParser(
-        prog="gaplint", usage="%(prog)s [options] files"
+        prog="gaplint", usage="%(prog)s [options] [files ...]"
     )
-    parser.add_argument("files", nargs="*", help="the files to lint")
 
     default = _DEFAULT_CONFIG["max-warnings"]
     parser.add_argument(
@@ -1437,6 +1436,9 @@ def _parse_cmd_line_args() -> Dict[str, Any]:
         default=None,
         help='path to config file (default: ".gaplint.yml" in git repo root dir)',
     )
+
+    parser.add_argument("files", nargs="*", help="the files to lint")
+    print(parser.parse_args(["./examples/aaa", "./aaa", "./bbb"]))
 
     args = parser.parse_args()
 
@@ -2333,7 +2335,7 @@ def __at_exit(
 
 
 # TODO fix linting errors here
-def main(  # pylint: disable=too-many-locals, too-many-statements, too-many-branches
+def run_gaplint(  # pylint: disable=too-many-locals, too-many-statements, too-many-branches
     _cmd_line_args = None,
     **kwargs,
 ) -> None:
@@ -2454,7 +2456,9 @@ def main(  # pylint: disable=too-many-locals, too-many-statements, too-many-bran
 
     __at_exit(args, total_num_warnings, start_time)
 
+def main():
+    _cmd_line_args = _parse_cmd_line_args()
+    run_gaplint(_cmd_line_args)
 
 if __name__ == "__main__":
-    _cmd_line_args = _parse_cmd_line_args()
-    main(_cmd_line_args)
+    main()

--- a/gaplint.py
+++ b/gaplint.py
@@ -2382,7 +2382,7 @@ def run_gaplint(  # pylint: disable=too-many-locals, too-many-statements, too-ma
     if _cmd_line_args is None:
         # This step is only done if we are not run as a script, in which case
         # we need to initialize the command line args to have the correct
-        # defaults otherwise the __merge_args function breaks because of how its
+        # defaults otherwise the __merge_args function breaks because of how it's
         # implemented.
         cmd_line_args = _parse_cmd_line_args([])
         cmd_line_args["files"] = None

--- a/gaplint.py
+++ b/gaplint.py
@@ -2472,6 +2472,11 @@ def run_gaplint(  # pylint: disable=too-many-locals, too-many-statements, too-ma
     __at_exit(args, total_num_warnings, start_time)
 
 def main():
+    """Entrypoint for the gaplint script.
+
+    Should not be called programmatically due to issues with command line
+    argument parsing, use the `run_gaplint` function instead.
+    """
     _cmd_line_args = _parse_cmd_line_args()
     run_gaplint(_cmd_line_args)
 

--- a/gaplint.py
+++ b/gaplint.py
@@ -1320,8 +1320,12 @@ def __explain(args: Dict[str, Any]) -> None:
     sys.exit(0)
 
 
-def _parse_cmd_line_args() -> Dict[str, Any]:
-    """
+def _parse_cmd_line_args(arglist = None) -> Dict[str, Any]:
+    """Parse the given arglist.
+
+    If arglist is none, parses the arglist passed to the command invoking this
+    function.
+
     Note that the default value for each argument is set to None here, so that
     we can detect where a parameter was actually set in __merge_args. The
     actual default value is installed in __merge_args.
@@ -1439,7 +1443,10 @@ def _parse_cmd_line_args() -> Dict[str, Any]:
 
     parser.add_argument("files", nargs="*", help="the files to lint")
 
-    args = parser.parse_args()
+    if arglist is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(arglist)
 
     result = {}
     for arg in dir(args):
@@ -2371,8 +2378,14 @@ def run_gaplint(  # pylint: disable=too-many-locals, too-many-statements, too-ma
         _info_verbose("Debug off . . .")
 
     # gather args from different places
+    # TODO: Clean this mess
     if _cmd_line_args is None:
-        cmd_line_args = {}
+        # This step is only done if we are not run as a script, in which case
+        # we need to initialize the command line args to have the correct
+        # defaults otherwise the __merge_args function breaks because of how its
+        # implemented.
+        cmd_line_args = _parse_cmd_line_args([])
+        cmd_line_args["files"] = None
     else:
         cmd_line_args = _cmd_line_args
     kwargs = _parse_kwargs(kwargs)
@@ -2416,7 +2429,10 @@ def run_gaplint(  # pylint: disable=too-many-locals, too-many-statements, too-ma
             __at_exit(args, nr_warnings, start_time)
 
     n = len(Rule.all_suppressible_codes())
-    m = len(args["disable"])
+    if "all" not in args["disable"]:
+        m = len(args["disable"])
+    else:
+        m = n
     _info_action(
         f"Analysing {len(args['files'])} files with {n - m} / {n} rules!"
     )

--- a/gaplint.py
+++ b/gaplint.py
@@ -1438,7 +1438,6 @@ def _parse_cmd_line_args() -> Dict[str, Any]:
     )
 
     parser.add_argument("files", nargs="*", help="the files to lint")
-    print(parser.parse_args(["./examples/aaa", "./aaa", "./bbb"]))
 
     args = parser.parse_args()
 

--- a/tests/test_gaplint.py
+++ b/tests/test_gaplint.py
@@ -10,7 +10,7 @@ from os.path import exists, isdir
 
 import gaplint
 from gaplint import Diagnostic
-from gaplint import main as run_gaplint
+from gaplint import run_gaplint
 
 # See tests/pickle_expected_output.py
 _INPUT_FILES = glob.glob("./tests/input/*")


### PR DESCRIPTION
This PR introduces a separation between ~church and state~ command line arg parsing and kwarg parsing, therefore fixing #57 . The fix essentially makes the `main` function a wrapper around `run_gaplint` function, so that the entrypoint for the gaplint script is now `main`, which triggers command line arg parsing, but using the `run_gaplint` script programmatically does not trigger command line arg parsing. Its a bit messy at the moment so that none of the actual argument parsing and merging functions need to be changed, which hopefully does not break the parsing. In the future a rewrite of `__merge_args` function may be needed.